### PR TITLE
soong: explicitly specify name of Gzosp variables struct

### DIFF
--- a/android/variable.go
+++ b/android/variable.go
@@ -88,7 +88,7 @@ type variableProperties struct {
 			Cppflags []string
 		}
 		// include gzosp variables
-		*android.Product_variables
+		Gzosp android.Product_variables
 
 	} `android:"arch_variant"`
 }
@@ -157,7 +157,7 @@ type productVariables struct {
 	Override_rs_driver *string `json:",omitempty"`
 
 	// include gzosp variables
-	*android.ProductVariables
+	Gzosp android.ProductVariables
 }
 
 func boolPtr(v bool) *bool {


### PR DESCRIPTION
Change-Id: Ic754b8a13658ddc40620f985581bd1754b780b15